### PR TITLE
csrf is not set on cookie, so return null

### DIFF
--- a/src/Pecee/Http/Security/CookieTokenProvider.php
+++ b/src/Pecee/Http/Security/CookieTokenProvider.php
@@ -63,7 +63,7 @@ class CookieTokenProvider implements ITokenProvider
     public function setToken(string $token): void
     {
         $this->token = $token;
-        setcookie(static::CSRF_KEY, $token, (time() + 60) * $this->cookieTimeoutMinutes, '/', ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
+        setcookie(static::CSRF_KEY, $token, time() + (60 * $this->cookieTimeoutMinutes), '/', ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
     }
 
     /**


### PR DESCRIPTION
On the browser
 @/*
Warning: setcookie() expects parameter 3 to be integer, float given in C:\xampp\htdocs\suggestotron\vendor\pecee\simple-router\src\Pecee\Http\Security\CookieTokenProvider.php on line 66
*/
This is because, when the cookie is set, the value became a float because  a bad operation  in expires parameter

<code>
(time() + 60) * $this->cookieTimeoutMinutes
</code>

node test
![image](https://user-images.githubusercontent.com/44674391/57162093-9b1e1100-6dc3-11e9-9c72-2374fa126b6d.png)

<code>
time() + (60 * $this->cookieTimeoutMinutes)
</code>

PR with collaboration Hugo de Carmo
@https://github.com/spelcaster

obs:  sorry my english